### PR TITLE
Set maximum-scale in viewport meta tag

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1"
+    />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Social Whiskey Drinking" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />


### PR DESCRIPTION
Should prevent Safari from duck in when focusing on input.

https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone