### PR TITLE
order targets by convention and add make all target

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -2,13 +2,13 @@ git_commit := $(shell git rev-parse --short HEAD)
 export REACT_APP_VERSION := $(git_commit)
 
 .PHONY: build
-	build:
+build:
 	npm install
 	npm run build
 	echo $(REACT_APP_VERSION) > build/version.txt
 
 .PHONY: start
-	start:
+start:
 	npm run start
 
 .PHONY: all


### PR DESCRIPTION
Makefile targets are usually ordered by convention. I have also added an "all" target to build all the targets in one go. This produces a positive developer experience.  