### PR TITLE
No Object.create(null) in FirebaseStore

### DIFF
--- a/app/src/components/context/FirebaseStore.tsx
+++ b/app/src/components/context/FirebaseStore.tsx
@@ -21,7 +21,7 @@ const Context = createContext<FirebaseStoreContextValue>({
   queue: () => undefined,
 });
 
-const EMPTY = Object.create(null);
+const EMPTY = {};
 
 export const FirebaseStoreContext: React.FC = ({ children }) => {
   const [store, setStore] = useState<Entries>(EMPTY);


### PR DESCRIPTION
It is overwritten anyway by normal object.